### PR TITLE
update scan workflow

### DIFF
--- a/.github/workflows/scan-image.yml
+++ b/.github/workflows/scan-image.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Scan Image
         id: scan_image
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
         with:
           image-ref: jml-report
           exit-code: 1
@@ -43,6 +46,9 @@ jobs:
         if: failure() && steps.scan_image.outcome == 'failure'
         id: scan_image_on_failure
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
         with:
           image-ref: jml-report
           exit-code: 1


### PR DESCRIPTION
This pr updates the scan workflow to allow trivy to access the database over the public aws ecr repo rather than github to fix the 'toomanyrequest' error